### PR TITLE
Add ellipsis when x axis label goes off screen to the left

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -1579,7 +1579,7 @@ export class MekkoChart implements IVisual {
             let width: number,
                 allowedLength: number;
 
-            if (columnsWidth.length >= index) {
+            if (index < columnsWidth.length) {
                 width = columnsWidth[index];
                 allowedLength = axisProperties.scale(width);
             } else {

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -1558,12 +1558,14 @@ export class MekkoChart implements IVisual {
         angle: number,
         margin: IMargin
     ): void {
+        const svgOffsetX: number = (text.node() as SVGTextElement)?.ownerSVGElement?.getBoundingClientRect().x ?? 0;
         text.each(function () {
             const boundingRect: DOMRect = this.getBoundingClientRect();
-            if (boundingRect.x > margin.left) {
+            const relativeX: number = boundingRect.x - svgOffsetX;
+            if (relativeX > margin.left) {
                 return;
             }
-            const desiredWidth: number = boundingRect.width + boundingRect.x - margin.left;
+            const desiredWidth: number = boundingRect.width + relativeX - margin.left;
             const desiredTextLength: number = desiredWidth / Math.cos(angle * Math.PI / 180);
             textMeasurementService.svgEllipsis(this, desiredTextLength);
         });

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -1553,6 +1553,22 @@ export class MekkoChart implements IVisual {
         };
     }
 
+    private static svgEllipsis(
+        text: Selection,
+        angle: number,
+        margin: IMargin
+    ): void {
+        text.each(function () {
+            const boundingRect: DOMRect = this.getBoundingClientRect();
+            if (boundingRect.x > margin.left) {
+                return;
+            }
+            const desiredWidth: number = boundingRect.width + boundingRect.x - margin.left;
+            const desiredTextLength: number = desiredWidth / Math.cos(angle * Math.PI / 180);
+            textMeasurementService.svgEllipsis(this, desiredTextLength);
+        });
+    }
+
     private static wordBreak(
         text: Selection,
         axisProperties: IAxisProperties,
@@ -1563,22 +1579,12 @@ export class MekkoChart implements IVisual {
             let width: number,
                 allowedLength: number;
 
-            const node: Selection = select(this);
-
             if (columnsWidth.length >= index) {
                 width = columnsWidth[index];
                 allowedLength = axisProperties.scale(width);
             } else {
                 allowedLength = axisProperties.xLabelMaxWidth;
             }
-
-            node
-                .classed(MekkoChart.LabelRotationSelector.className, false)
-                .classed(MekkoChart.LabelMiddleSelector.className, true)
-                .style("--rotation", null)
-                .attr("dx", MekkoChart.DefaultLabelDx)
-                .attr("dy", MekkoChart.DefaultLabelDy)
-                .attr("transform", MekkoChart.DefaultLabelRotate);
 
             textMeasurementService.wordBreak(
                 this,
@@ -1695,6 +1701,12 @@ export class MekkoChart implements IVisual {
             const rotationEnabled: boolean = this.settingsModel.xAxisLabels.enableRotataion.value;
             if (!rotationEnabled) {
                 xAxisTextNodes
+                    .classed(MekkoChart.LabelRotationSelector.className, false)
+                    .classed(MekkoChart.LabelMiddleSelector.className, true)
+                    .style("--rotation", null)
+                    .attr("dx", MekkoChart.DefaultLabelDx)
+                    .attr("dy", MekkoChart.DefaultLabelDy)
+                    .attr("transform", MekkoChart.DefaultLabelRotate)
                     .call(
                         MekkoChart.wordBreak,
                         axes.x,
@@ -1707,7 +1719,8 @@ export class MekkoChart implements IVisual {
                     .classed(MekkoChart.LabelRotationSelector.className, true)
                     .style("--rotation", `${-this.settingsModel.xAxisLabels.rotationAngle.value}deg`)
                     .attr("dx", MekkoChart.DefaultLabelDx)
-                    .attr("dy", MekkoChart.DefaultLabelDy);
+                    .attr("dy", MekkoChart.DefaultLabelDy)
+                    .call(MekkoChart.svgEllipsis, this.settingsModel.xAxisLabels.rotationAngle.value, this.margin);
             }
         }
         else {

--- a/test/visualData.ts
+++ b/test/visualData.ts
@@ -49,7 +49,7 @@ export class MekkoChartData extends TestDataViewBuilder {
     public static ColumnWidth: string = "Sum Total Units This Year";
 
     public valuesCategorySeries: string[][] = [
-        ["William", "DE"],
+        ["William Long Middle Name Long Last Name", "DE"],
         ["James", "GA"],
         ["Harper", "KY"],
         ["Aiden", "MD"],

--- a/test/visualTest.ts
+++ b/test/visualTest.ts
@@ -279,6 +279,33 @@ describe("MekkoChart", () => {
             }, 300);
         });
 
+        it("rotated X axis labels shouldn't be cut off", (done) => {
+            dataView.metadata.objects = {
+                xAxisLabels: {
+                    enableRotataion: true,
+                    rotationAngle: 45
+                },
+                categoryAxis: {
+                    show: true,
+                    showAxisTitle: true
+                },
+                valueAxis: {
+                    show: true,
+                    showAxisTitle: true
+                }
+            };
+
+            visualBuilder.updateRenderTimeout(dataView, () => {
+                visualBuilder.xAxisTicks.forEach((tick: Element) => {
+                    checkAxisLabels(
+                        visualBuilder.mainElement,
+                        tick);
+                });
+
+                done();
+            }, 300);
+        });
+
         function checkAxisLabels(mainElement: Element, textElement: Element): void {
             expect(isTextElementInOrOutElement(
                 mainElement,
@@ -299,7 +326,7 @@ describe("MekkoChart", () => {
             checkMultisilection(ClickEventType.ShiftKey);
         });
 
-        function checkMultisilection(eventType: number): void{
+        function checkMultisilection(eventType: number): void {
             dataView = defaultDataViewBuilder.getDataView([
                 MekkoChartData.ColumnCategory,
                 MekkoChartData.ColumnY
@@ -845,7 +872,7 @@ describe("MekkoChart", () => {
                 visualBuilder.updateRenderTimeout(dataView, () => {
                     const xAxisElement: HTMLElement = visualBuilder.mainElement.querySelector(".x.axis g.tick text");
                     const xAxisElementComputedStyle: CSSStyleDeclaration = getComputedStyle(xAxisElement);
-                    const xAxisFontSize: number= parseFloat(xAxisElementComputedStyle.getPropertyValue("font-size"));
+                    const xAxisFontSize: number = parseFloat(xAxisElementComputedStyle.getPropertyValue("font-size"));
 
                     expect(Math.round(xAxisFontSize)).toBe(Math.round(fromPointToPixel(categoryAxisFontSize)));
 
@@ -933,7 +960,7 @@ describe("MekkoChart", () => {
                 key: string;
                 data: number;
             }
-            
+
             let data = dataView.categorical.values.grouped().map(v => { return { key: v.name, data: sum(v.values[0].values) }; });
 
             let reduced = {};
@@ -1202,7 +1229,7 @@ describe("MekkoChart", () => {
                     columns[1].dispatchEvent(enterEvent);
                     expect(columns[1].getAttribute("aria-selected")).toBe("true");
 
-                    columns.splice(1,1);
+                    columns.splice(1, 1);
                     columns.forEach((column: HTMLElement) => {
                         expect(column.getAttribute("aria-selected")).toBe("false");
                     });
@@ -1228,7 +1255,7 @@ describe("MekkoChart", () => {
                     columns[1].dispatchEvent(enterEvent);
                     expect(columns[1].getAttribute("aria-selected")).toBe("true");
 
-                    columns.splice(1,1);
+                    columns.splice(1, 1);
                     columns.forEach((column: HTMLElement) => {
                         expect(column.getAttribute("aria-selected")).toBe("false");
                     });
@@ -1288,7 +1315,7 @@ describe("MekkoChart", () => {
             );
         });
 
-        function checkKeyboardMultiSelection(keyboardMultiselectionEvent: KeyboardEvent): void{
+        function checkKeyboardMultiSelection(keyboardMultiselectionEvent: KeyboardEvent): void {
             const enterEvent = new KeyboardEvent("keydown", { code: "Enter", bubbles: true });
 
             const columns: HTMLElement[] = [...visualBuilder.columns];

--- a/test/visualTest.ts
+++ b/test/visualTest.ts
@@ -306,6 +306,25 @@ describe("MekkoChart", () => {
             }, 300);
         });
 
+        it("rotated X axis labels should use ellipsis truncation", (done) => {
+            dataView.metadata.objects = {
+                xAxisLabels: {
+                    enableRotataion: true,
+                    rotationAngle: 45
+                },
+                categoryAxis: {
+                    show: true
+                }
+            };
+
+            const svgEllipsisSpy = spyOn<any>(MekkoChart, "svgEllipsis").and.callThrough();
+
+            visualBuilder.updateRenderTimeout(dataView, () => {
+                expect(svgEllipsisSpy).toHaveBeenCalled();
+                done();
+            }, 300);
+        });
+
         function checkAxisLabels(mainElement: Element, textElement: Element): void {
             expect(isTextElementInOrOutElement(
                 mainElement,


### PR DESCRIPTION
Right now, if some long labels can go out of bounds on the left when rotated.

With this PR, labels will now get ellipsis if they are too long, so they don't go out of bounds.

<img width="1668" height="793" alt="image" src="https://github.com/user-attachments/assets/ccbacf8d-6b45-470e-aa46-3f9dcb5af3b7" />
